### PR TITLE
Support more options for openapi3 responses

### DIFF
--- a/lib/tomograph/openapi/openapi3.rb
+++ b/lib/tomograph/openapi/openapi3.rb
@@ -32,7 +32,16 @@ module Tomograph
             response['content'] = @documentation.dig(*response_description_path)['content']
           end
 
-          result += responses_by_content_types(response['content'], response_code)
+          # Content can be nil if response body is not provided
+          if response['content'].nil?
+            result.push(
+              'status' => response_code,
+              'body'=> {},
+              'content-type' => ''
+            )
+          else
+            result += responses_by_content_types(response['content'], response_code)
+          end
         end
         result
       end

--- a/lib/tomograph/openapi/openapi3.rb
+++ b/lib/tomograph/openapi/openapi3.rb
@@ -9,38 +9,38 @@ module Tomograph
       end
 
       def to_tomogram
-        @tomogram ||= @documentation['paths'].each_with_object([]) do |action, result|
-          action[1].keys.each do |method|
+        @tomogram ||= @documentation['paths'].each_with_object([]) do |(path, action_definition), result|
+          action_definition.keys.each do |method|
             result.push(Tomograph::Tomogram::Action.new(
-                          path: "#{@prefix}#{action[0]}",
+                          path: "#{@prefix}#{path}",
                           method: method.upcase,
                           content_type: '',
                           requests: [],
-                          responses: responses(action[1][method]['responses']),
+                          responses: responses(action_definition[method]['responses']),
                           resource: ''
                         ))
           end
         end
       end
 
-      def responses(resp)
-        resp.inject([]) do |result, response|
-          if response[1]['content'].nil?
+      def responses(responses_definitions)
+        responses_definitions.inject([]) do |result, (response_code, response)|
+          if response['content'].nil?
             # TODO: 403Forbidden
             result.push(
-              'status' => response[0],
+              'status' => response_code,
               'body' => {},
               'content-type' => 'application/json'
             )
-          elsif response[1]['content'].values[0]['schema']
+          elsif response['content'].values[0]['schema']
             result.push(
-              'status' => response[0],
-              'body' => schema(response[1]['content'].values[0]['schema']),
+              'status' => response_code,
+              'body' => schema(response['content'].values[0]['schema']),
               'content-type' => 'application/json'
             )
           else
             result.push(
-              status: response[0],
+              status: response_code,
               body: {},
               'content-type': ''
             )

--- a/lib/tomograph/openapi/openapi3.rb
+++ b/lib/tomograph/openapi/openapi3.rb
@@ -16,14 +16,14 @@ module Tomograph
                           method: method.upcase,
                           content_type: '',
                           requests: [],
-                          responses: responses(action[1][method]['responses'], @documentation['components']['schemas']),
+                          responses: responses(action[1][method]['responses']),
                           resource: ''
                         ))
           end
         end
       end
 
-      def responses(resp, defi)
+      def responses(resp)
         resp.inject([]) do |result, response|
           if response[1]['content'].nil?
             # TODO: 403Forbidden
@@ -35,7 +35,7 @@ module Tomograph
           elsif response[1]['content'].values[0]['schema']
             result.push(
               'status' => response[0],
-              'body' => schema(response[1]['content'].values[0]['schema'], defi),
+              'body' => schema(response[1]['content'].values[0]['schema']),
               'content-type' => 'application/json'
             )
           else
@@ -48,7 +48,8 @@ module Tomograph
         end
       end
 
-      def schema(sche, defi)
+      def schema(sche)
+        defi = @documentation['components']['schemas']
         if sche.keys.include?('$ref')
           sche.merge!('components' => {})
           sche['components'].merge!('schemas' => {})

--- a/spec/fixtures/openapi3/one_code_two_content_types.json
+++ b/spec/fixtures/openapi3/one_code_two_content_types.json
@@ -1,0 +1,44 @@
+[
+  {
+    "path": "/accounts/{accountId}",
+    "method": "GET",
+    "content-type": "",
+    "requests": [
+    ],
+    "responses": [
+      {
+        "status": "200",
+        "body": {
+          "$ref": "#/components/schemas/Account",
+          "components": {
+            "schemas": {
+              "Account": {
+                "description": "Account data",
+                "type": "object",
+                "parameters": {
+                  "id": {
+                    "type": "integer",
+                    "required": true
+                  },
+                  "name": {
+                    "type": "string",
+                    "required": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "content-type": "application/json"
+      },
+      {
+        "status": "200",
+        "body": {
+          "type": "string"
+        },
+        "content-type": "text/plain"
+      }
+    ],
+    "resource": ""
+  }
+]

--- a/spec/fixtures/openapi3/one_code_two_content_types.yml
+++ b/spec/fixtures/openapi3/one_code_two_content_types.yml
@@ -1,0 +1,41 @@
+openapi: 3.1.3
+servers:
+  - url: 'http://localhost:3000/api/v2/storefront'
+info:
+  version: 2.0.0
+  title: Test API
+  description: API for testing specs. It has two responses with same code but different content-types
+
+paths:
+  /accounts/{accountId}:
+    get:
+      summary: Get account data
+      parameters:
+        - name: accountId
+          in: query
+          schema:
+            type: integer
+          required: true
+      responses:
+        '200':
+          description: Account data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+            text/plain:
+              schema:
+                type: string
+
+components:
+  schemas:
+    Account:
+      type: object
+      description: Account data
+      parameters:
+        id:
+          type: integer
+          required: true
+        name:
+          type: string
+          required: true

--- a/spec/fixtures/openapi3/response_as_ref_and_plain.json
+++ b/spec/fixtures/openapi3/response_as_ref_and_plain.json
@@ -1,0 +1,76 @@
+[
+  {
+    "path": "/accounts/{accountId}",
+    "method": "GET",
+    "content-type": "",
+    "requests": [
+    ],
+    "responses": [
+      {
+        "status": "200",
+        "body": {
+          "$ref": "#/components/schemas/Account",
+          "components": {
+            "schemas": {
+              "Account": {
+                "description": "Account data",
+                "type": "object",
+                "parameters": {
+                  "id": {
+                    "type": "integer",
+                    "required": true,
+                    "example": 1
+                  },
+                  "name": {
+                    "type": "string",
+                    "required": true,
+                    "example": "Jane Doe"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "content-type": "application/json"
+      },
+      {
+        "status": "403",
+        "body": {
+          "type": "object",
+          "parameters": {
+            "error": {
+              "type": "string",
+              "required": true,
+              "example": "Access denied"
+            }
+          }
+        },
+        "content-type": "application/json"
+      },
+      {
+        "status": "404",
+        "body": {
+          "$ref": "#/components/schemas/NotFound",
+          "components": {
+            "schemas": {
+              "NotFound": {
+                "description": "Not found error",
+                "type": "object",
+                "parameters": {
+                  "error": {
+                    "type": "string",
+                    "required": true,
+                    "default": "Account not found",
+                    "example": "Account not found"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "content-type": "application/json"
+      }
+    ],
+    "resource": ""
+  }
+]

--- a/spec/fixtures/openapi3/response_as_ref_and_plain.yml
+++ b/spec/fixtures/openapi3/response_as_ref_and_plain.yml
@@ -1,0 +1,73 @@
+openapi: 3.1.3
+servers:
+  - url: 'http://localhost:3000/api/v2/storefront'
+info:
+  version: 2.0.0
+  title: Test API
+  description: API for testing specs. It has two responses with same code but different content-types described in a components section
+
+paths:
+  /accounts/{accountId}:
+    get:
+      summary: Get account data
+      parameters:
+        - name: accountId
+          in: query
+          schema:
+            type: integer
+          required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/200Ok'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                parameters:
+                  error:
+                    type: string
+                    required: true
+                    example: Access denied
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+
+components:
+  responses:
+    200Ok:
+      description: Account data
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Account'
+          example:
+            id: 10
+            name: John Doe
+
+  schemas:
+    Account:
+      type: object
+      description: Account data
+      parameters:
+        id:
+          type: integer
+          required: true
+          example: 1
+        name:
+          type: string
+          required: true
+          example: Jane Doe
+    NotFound:
+      type: object
+      description: Not found error
+      parameters:
+        error:
+          type: string
+          required: true
+          default: Account not found
+          example: Account not found

--- a/spec/fixtures/openapi3/response_is_a_ref.json
+++ b/spec/fixtures/openapi3/response_is_a_ref.json
@@ -1,0 +1,44 @@
+[
+  {
+    "path": "/accounts/{accountId}",
+    "method": "GET",
+    "content-type": "",
+    "requests": [
+    ],
+    "responses": [
+      {
+        "status": "200",
+        "body": {
+          "$ref": "#/components/schemas/Account",
+          "components": {
+            "schemas": {
+              "Account": {
+                "description": "Account data",
+                "type": "object",
+                "parameters": {
+                  "id": {
+                    "type": "integer",
+                    "required": true
+                  },
+                  "name": {
+                    "type": "string",
+                    "required": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "content-type": "application/json"
+      },
+      {
+        "status": "200",
+        "body": {
+          "type": "string"
+        },
+        "content-type": "text/plain"
+      }
+    ],
+    "resource": ""
+  }
+]

--- a/spec/fixtures/openapi3/response_is_a_ref.yml
+++ b/spec/fixtures/openapi3/response_is_a_ref.yml
@@ -1,0 +1,47 @@
+openapi: 3.1.3
+servers:
+  - url: 'http://localhost:3000/api/v2/storefront'
+info:
+  version: 2.0.0
+  title: Test API
+  description: API for testing specs. It has two responses with same code but different content-types described in a components section
+
+paths:
+  /accounts/{accountId}:
+    get:
+      summary: Get account data
+      parameters:
+        - name: accountId
+          in: query
+          schema:
+            type: integer
+          required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/200Ok'
+
+components:
+  responses:
+    200Ok:
+      description: Account data
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Account'
+          example:
+            id: 10
+            name: John Doe
+        text/plain:
+          schema:
+            type: string
+  schemas:
+    Account:
+      type: object
+      description: Account data
+      parameters:
+        id:
+          type: integer
+          required: true
+        name:
+          type: string
+          required: true

--- a/spec/fixtures/openapi3/response_with_empty_body.json
+++ b/spec/fixtures/openapi3/response_with_empty_body.json
@@ -1,0 +1,18 @@
+[
+  {
+    "path": "/accounts/{accountId}",
+    "method": "GET",
+    "content-type": "",
+    "requests": [
+    ],
+    "responses": [
+      {
+        "status": "404",
+        "body": {
+        },
+        "content-type": ""
+      }
+    ],
+    "resource": ""
+  }
+]

--- a/spec/fixtures/openapi3/response_with_empty_body.yml
+++ b/spec/fixtures/openapi3/response_with_empty_body.yml
@@ -1,0 +1,34 @@
+openapi: 3.1.3
+servers:
+  - url: 'http://localhost:3000/api/v2/storefront'
+info:
+  version: 2.0.0
+  title: Test API
+  description: API for testing specs. Response have an empty body
+
+paths:
+  /accounts/{accountId}:
+    get:
+      summary: Get account data
+      parameters:
+        - name: accountId
+          in: query
+          schema:
+            type: integer
+          required: true
+      responses:
+        '404':
+          description: Account not found
+
+components:
+  schemas:
+    Account:
+      type: object
+      description: Account data
+      parameters:
+        id:
+          type: integer
+          required: true
+        name:
+          type: string
+          required: true

--- a/spec/fixtures/tomogram/spree.json
+++ b/spec/fixtures/tomogram/spree.json
@@ -174,13 +174,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "403",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "You are not authorized to access this page.",
+              "example": "You are not authorized to access this page."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -360,7 +367,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -381,7 +388,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -561,7 +568,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -582,7 +589,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -682,13 +689,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "403",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "You are not authorized to access this page.",
+              "example": "You are not authorized to access this page."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -788,13 +802,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "403",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "You are not authorized to access this page.",
+              "example": "You are not authorized to access this page."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -894,13 +915,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "403",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "You are not authorized to access this page.",
+              "example": "You are not authorized to access this page."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -1051,13 +1079,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "403",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "You are not authorized to access this page.",
+              "example": "You are not authorized to access this page."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -1207,13 +1242,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "403",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "You are not authorized to access this page.",
+              "example": "You are not authorized to access this page."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -1919,13 +1961,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "403",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "You are not authorized to access this page.",
+              "example": "You are not authorized to access this page."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -2629,13 +2678,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "403",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "You are not authorized to access this page.",
+              "example": "You are not authorized to access this page."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -3344,8 +3400,15 @@
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -4049,7 +4112,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -4753,13 +4816,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -5463,13 +5533,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -6173,7 +6250,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -6194,7 +6271,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -6898,13 +6975,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -7608,13 +7692,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -8318,7 +8409,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -8339,7 +8430,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -9043,7 +9134,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -9064,7 +9155,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -9161,13 +9252,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -9871,7 +9969,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -9892,13 +9990,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -10602,7 +10707,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -10623,13 +10728,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -11333,7 +11445,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -11354,13 +11466,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -12064,7 +12183,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -12085,13 +12204,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -12795,7 +12921,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -12816,13 +12942,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -13526,7 +13659,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "422",
@@ -13547,13 +13680,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -13617,13 +13757,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -13849,13 +13996,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -14604,7 +14758,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -15300,13 +15454,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -15795,7 +15956,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -16231,13 +16392,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -16351,7 +16519,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -16486,13 +16654,20 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       },
       {
         "status": "404",
         "body": {
+          "properties": {
+            "error": {
+              "type": "string",
+              "default": "The resource you were looking for could not be found.",
+              "example": "The resource you were looking for could not be found."
+            }
+          }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""
@@ -16627,7 +16802,7 @@
             }
           }
         },
-        "content-type": "application/json"
+        "content-type": "application/vnd.api+json"
       }
     ],
     "resource": ""

--- a/spec/lib/tomograph/tomogram_spec.rb
+++ b/spec/lib/tomograph/tomogram_spec.rb
@@ -1113,6 +1113,15 @@ RSpec.describe Tomograph::Tomogram do
         end
       end
 
+      context 'if response has an empty body' do
+        let(:json_schema) { 'spec/fixtures/openapi3/response_with_empty_body.json' }
+        let(:documentation) { 'response_with_empty_body.yml' }
+
+        it 'parses documents right' do
+          expect(subject).to eq(parsed)
+        end
+      end
+
       context 'if action has two responses with one code and different content-types' do
         let(:json_schema) { 'spec/fixtures/openapi3/one_code_two_content_types.json' }
         let(:documentation) { 'one_code_two_content_types.yml' }

--- a/spec/lib/tomograph/tomogram_spec.rb
+++ b/spec/lib/tomograph/tomogram_spec.rb
@@ -1103,6 +1103,33 @@ RSpec.describe Tomograph::Tomogram do
           end
         end
       end
+
+      context 'if one response is a ref, others are described inline with and without schema ref' do
+        let(:json_schema) { 'spec/fixtures/openapi3/response_as_ref_and_plain.json' }
+        let(:documentation) { 'response_as_ref_and_plain.yml' }
+
+        it 'parses documents right' do
+          expect(subject).to eq(parsed)
+        end
+      end
+
+      context 'if action has two responses with one code and different content-types' do
+        let(:json_schema) { 'spec/fixtures/openapi3/one_code_two_content_types.json' }
+        let(:documentation) { 'one_code_two_content_types.yml' }
+
+        it 'parses documents right' do
+          expect(subject).to eq(parsed)
+        end
+
+        context 'and response is defined in components/responses section' do
+          let(:json_schema) { 'spec/fixtures/openapi3/response_is_a_ref.json' }
+          let(:documentation) { "response_is_a_ref.yml" }
+
+          it 'parses documents right' do
+            expect(subject).to eq(parsed)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This request adds missing support for parsing responses with the same status code, but different content types. E.g.:
```yml
...
responses:
  '200':
    description: Foo
    content:
      application/json:
        ...
      text/plain:
        ...
```

It also adds good support for using `$ref` in a `responses` like this:
```yml
...
responses:
  '404':
    $ref: '#/components/responses/404NotFound'

...

components:
  responses:
    404NotFound:
      description: ...
      content: ...
```

And also add support for responses without payloads:
```yml
...
responses:
  '404':
    description: Not found
```